### PR TITLE
Fix subnet creation & add flow log configuration

### DIFF
--- a/firecloud_project.py
+++ b/firecloud_project.py
@@ -85,6 +85,11 @@ def create_high_security_network(context):
   subnetworks = []
   for region in FIRECLOUD_NETWORK_REGIONS:
     subnetworks.append({
+        # We append the region to the subnetwork's DM resource name, since
+        # each resource name needs to be globally unique within the deployment.
+        'resourceName': FIRECLOUD_VPC_SUBNETWORK_NAME + '_' + region,
+        # We want all subnetworks to have the same object name, since this most
+        # closely mirrors how auto-mode subnets work and is what PAPI expects.
         'name': FIRECLOUD_VPC_SUBNETWORK_NAME,
         'region': region,
         'ipCidrRange': FIRECLOUD_NETWORK_REGIONS[region],
@@ -95,6 +100,7 @@ def create_high_security_network(context):
       'type': 'templates/network.py',
       'name': 'fc-network',
       'properties': {
+          'resourceName': 'network',
           'name': FIRECLOUD_VPC_NETWORK_NAME,
           'projectId': '$(ref.fc-project.projectId)',
           'autoCreateSubnetworks': False,

--- a/templates/network.py
+++ b/templates/network.py
@@ -17,17 +17,17 @@
 def generate_config(context):
   """ Entry point for the deployment resources. """
 
-  name = context.properties['name']
-  network_self_link = '$(ref.{}.selfLink)'.format(name)
+  resource_name = context.properties['resourceName']
+  network_self_link = '$(ref.{}.selfLink)'.format(resource_name)
 
   resources = []
 
   network_resource = {
-      'name': name,
+      'name': resource_name,
       'type': 'gcp-types/compute-v1:networks',
       'properties': {
           'name':
-              name,
+              context.properties['name'],
           'project':
               context.properties['projectId'],
           'autoCreateSubnetworks':
@@ -52,7 +52,7 @@ def generate_config(context):
     subnetwork['network'] = network_self_link
 
     # All subnetworks  depend on the parent network resource.
-    subnetwork['dependsOn'] = [name]
+    subnetwork['dependsOn'] = [resource_name]
 
     # Create the subnetwork within the specified project if the property is
     # non-empty.
@@ -60,7 +60,7 @@ def generate_config(context):
       subnetwork['projectId'] = context.properties['projectId']
 
     resources.append({
-        'name': subnetwork['name'],
+        'name': subnetwork['resourceName'],
         'type': 'subnetwork.py',
         'properties': subnetwork
     })
@@ -70,7 +70,7 @@ def generate_config(context):
           resources,
       'outputs': [{
           'name': 'name',
-          'value': name
+          'value': resource_name
       }, {
           'name': 'selfLink',
           'value': network_self_link

--- a/templates/network.py.schema
+++ b/templates/network.py.schema
@@ -26,14 +26,20 @@ imports:
 required:
   - name
   - projectId
+  - resourceName
 
 properties:
   name:
     type: string
-    description: Name of the network resource.
+    description: Name of the network object.
   projectId:
     type: string
     description: The project ID to create the network in.
+  resourceName:
+    type: string
+    description: |
+      The Deployment Manager resource name. Must be unique within the
+      deployment.
   autoCreateSubnetworks:
     type: boolean
     default: false
@@ -45,7 +51,8 @@ properties:
     description: |
       An array of subnetworks, as defined in the `subnetwork.py` template.
       Example:
-        - name: test-subnetwork-1
+        - name: subnetwork
+          resourceName: subnetwork_uscentral1
           region: us-east1
           ipCidrRange: 10.116.48.0/22
           privateIpGoogleAccess: false

--- a/templates/project.py
+++ b/templates/project.py
@@ -212,7 +212,7 @@ def create_storage_logs_bucket(context, api_names_list):
         'type': 'gcp-types/storage-v1:bucketAccessControls',
         'properties': {
             'bucket': bucket_name,
-            'entity': 'group:cloud-storage-analytics@google.com',
+            'entity': 'group-cloud-storage-analytics@google.com',
             'role': 'WRITER'
         },
         'metadata': {

--- a/templates/subnetwork.py
+++ b/templates/subnetwork.py
@@ -17,11 +17,15 @@
 def generate_config(context):
   """ Entry point for the deployment resources. """
 
+  enable_flow_logs = context.properties.get('enableFlowLogs', False)
+
   subnetwork_resource = {
-      'name': context.properties['name'],
-      'type': 'gcp-types/compute-v1:subnetworks',
+      'name': context.properties['resourceName'],
+      'type': 'gcp-types/compute-beta:subnetworks',
       'properties': {
           # Required properties.
+          'name':
+              context.properties['name'],
           'network':
               context.properties['network'],
           'ipCidrRange':
@@ -33,13 +37,25 @@ def generate_config(context):
 
           # Optional properties, with defaults.
           'enableFlowLogs':
-              context.properties.get('enableFlowLogs', False),
+              enable_flow_logs,
           'privateIpGoogleAccess':
               context.properties.get('privateIpGoogleAccess', False),
           'secondaryIpRanges':
               context.properties.get('secondaryIpRanges', []),
       }
   }
+  
+  if enable_flow_logs:
+    # If flow logs are enabled, we want to adjust the default config in two ways:
+    # (1) Increase the sampling ratio (defaults to 0.5) so we sample all traffic.
+    # (2) Reduce the aggregation interval to 30 seconds (default is 5secs) to save on
+    #     storage.
+    subnetwork_resource['properties']['logConfig'] = {
+        'aggregationInterval': 'INTERVAL_30_SEC',
+        'enable': True,
+        'flowSampling': 1.0,
+        'metadata': 'INCLUDE_ALL_METADATA',
+    }
 
   # Pass the 'dependsOn' property to the subnetwork resource if present.
   if 'dependsOn' in context.properties:

--- a/templates/subnetwork.py.schema
+++ b/templates/subnetwork.py.schema
@@ -23,12 +23,13 @@ required:
   - network
   - projectId
   - region
+  - resourceName
 
 properties:
   name:
     type: string
     description: |
-      Name of the subnetwork. If not specified, the DM resource name is used.
+      Name of the subnetwork object.
   network:
     type: string
     description: |
@@ -40,6 +41,11 @@ properties:
   region:
     type: string
     description: The name of the region where the subnetwork resides.
+  resourceName:
+    type: string
+    description: |
+      The Deployment Manager resource name. Must be unique within the
+      deployment.
   ipCidrRange:
     type: string
     pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,2}$


### PR DESCRIPTION
The main thing fixed by this PR is to get Deployment Manager happy about using this template again. A few things:

1) Support a distinction between "DM resource name" and "GCP object name" for networks and subnetworks.
2) Fix a syntax change in the way GCS bucket IAM grants for groups works. (Now it's "group-" rather than "group:")
3) Switch to the beta compute API and use the beta-only "flowLogs" config, to pre-configure additional settings for our flow logs.