### PR TITLE
Name subnetworks the same as the network

### DIFF
--- a/firecloud_project.py
+++ b/firecloud_project.py
@@ -46,7 +46,7 @@ FIRECLOUD_REQUIRED_APIS = [
 ]
 
 FIRECLOUD_VPC_NETWORK_NAME = "network"
-FIRECLOUD_VPC_SUBNETWORK_NAME = "subnetwork"
+FIRECLOUD_VPC_SUBNETWORK_NAME = "network"
 
 def create_default_network(context):
   """Creates a default VPC network resource.


### PR DESCRIPTION
[Dataproc either wants subnetworks to be the same name as the network, or for you to specify the region explicitly.](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/network#creating_a_cluster_that_uses_your_vpc_network) I didn't want to futz with how we choose regions in Leo so I went for the former. Will try this with Leo and report back.