### PR TITLE
off by one

### DIFF
--- a/firecloud_project.py.schema
+++ b/firecloud_project.py.schema
@@ -80,7 +80,7 @@ properties:
       the folder instead of at the organization root level.
   projectId:
     type: string
-    pattern: ^[a-z][a-z0-9-]{5,28}[a-z0-9]$
+    pattern: ^[a-z][a-z0-9-]{4,28}[a-z0-9]$
     description: |
       The unique, user-assigned ID of the Project. It must be 6 to 30 lowercase
       letters, digits, or hyphens. It must start with a letter. Trailing


### PR DESCRIPTION
We have the regex for naming projects as `^[a-z][a-z0-9-]{5,28}[a-z0-9]$`

`[a-z]` = 1 char
`[a-z0-9-]{5,28}` = 5 chars
`[a-z0-9]$` = 1 char

That makes a minimum of 7 characters. But the Google minimum number of characters is 6, so it should say 4-28