### PR TITLE
IA-2041 Remove ICMP traffic open to the world in Terra billing projects

### DIFF
--- a/firecloud_project.py
+++ b/firecloud_project.py
@@ -190,16 +190,6 @@ def create_firewall(context):
         '$(ref.fc-network.resourceNames)',
       'rules': [
         {
-          'name': 'allow-icmp',
-          'description': 'Allow ICMP from anywhere.',
-          'allowed': [{
-            'IPProtocol': 'icmp',
-          }],
-          'direction': 'INGRESS',
-          'sourceRanges': ['0.0.0.0/0'],
-          'priority': 65534,
-        },
-        {
           'name': 'allow-internal',
           'description': 'Allow internal traffic on the network.',
           'allowed': [{

--- a/firecloud_project_test.py
+++ b/firecloud_project_test.py
@@ -95,7 +95,7 @@ class FirecloudProjectTest(unittest.TestCase):
     # A custom firewall resource is created with a set of expected rules.
     firewall = resource_with_name(resources, 'fc-firewall')
     self.assertEqual([x['name'] for x in firewall['properties']['rules']],
-                     ['allow-icmp', 'allow-internal', 'leonardo-ssl'])
+                     ['allow-internal', 'leonardo-ssl'])
 
   def test_private_ip_google_access(self):
     """Verifying changes are made with the privateIpGoogleAccess option."""


### PR DESCRIPTION
Context: https://broadworkbench.atlassian.net/browse/IA-2041

ICMP open to the world was flagged on an AoU security review. I don't think any of our infrastructure requires it. Dataproc requires ICMP but only on the internal network, which is enabled via a different rule.

I'm not clear on the process to actually regenerate & deploy the DM template. Is there CI attached to this repo?