### PR TITLE
IA-2152 enable kubernetes engine api

### DIFF
--- a/firecloud_project.py
+++ b/firecloud_project.py
@@ -65,7 +65,8 @@ FIRECLOUD_REQUIRED_APIS = [
   "monitoring.googleapis.com",
   "storage-api.googleapis.com",
   "storage-component.googleapis.com",
-  "dns.googleapis.com"
+  "dns.googleapis.com",
+  "container.googleapis.com"
 ]
 
 FIRECLOUD_VPC_NETWORK_NAME = "network"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2152

Will have a gpaclloc PR once this PR is merged

This is part of the effort for galaxy integration. Since Leonardo is launching galaxy in gke, we need container API to be enabled for gpalloc projects