### PR TITLE
[CA-1794] Remove billing permissions for billing project owners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,20 @@
 *.pyc
+.python-version
+venv
+.pytest_cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### VS Code ###
+.vscode/
+
+### Emacs backup files
+*.*~
+
+### Mac directory metadata
+.DS_Store

--- a/firecloud_project.py
+++ b/firecloud_project.py
@@ -17,6 +17,9 @@ Template Version History
     2:
       Added a privateIpGoogleAccess parameter, which fixes an issue where GCS bucket traffic could not be easily
       distinguished from internet egress. Started tracking template version numbers in project labels.
+    3:
+      Removed billing permissions for billing project owners. This is to prevent users from changing the billing account
+      on a Google Project through the Google console. Users will still be able to change the billing account through Terra.
 """
 import re
 
@@ -288,12 +291,6 @@ def create_iam_policies(context):
       {
         # Only FireCloud project owners are allowed to view the GCP project.
         'role': 'roles/viewer',
-        'members': owners_only,
-      },
-      {
-        # Owners can manage billing on the GCP project (to switch out
-        # billing accounts).
-        'role': 'roles/billing.projectManager',
         'members': owners_only,
       },
     ])

--- a/firecloud_project_test.py
+++ b/firecloud_project_test.py
@@ -158,11 +158,6 @@ class FirecloudProjectTest(unittest.TestCase):
             'members': ['group:proxy-group-owners@firecloud.org']
         })
     self.assertEqual(
-        policy_with_role(policies, 'roles/billing.projectManager'), {
-            'role': 'roles/billing.projectManager',
-            'members': ['group:proxy-group-owners@firecloud.org']
-        })
-    self.assertEqual(
         policy_with_role(policies, 'roles/bigquery.jobUser'), {
             'role':
                 'roles/bigquery.jobUser',


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CA-1794

We need to prevent users from changing the billing accounts via the Google console.

[follow-up PR in rawls to use the new DM template.](https://github.com/broadinstitute/firecloud-develop/pull/2823)